### PR TITLE
Add a `max_batch_size` argument to sequence pipelines to limit the number of sequence IDs processed per execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ results/
 src/*.bc
 regression.diffs
 regression.out
+
+.claude

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### pg\_incremental v1.4.0 (October 29, 2025)
+
+* Add a `max_batch_size` argument to sequence pipelines to limit the number of sequence IDs processed per execution
+* Improves handling of large batch uploads by allowing incremental processing in manageable chunks
+
 ### pg\_incremental v1.3.0 (May 15, 2025)
 * Adds an incremental.skip\_file function to use for erroneuous files in file pipelines
 * Removes the hard dependency on pg\_cron at CREATE EXTENSION time

--- a/README.md
+++ b/README.md
@@ -106,6 +106,33 @@ When creating the pipeline, the command is executed immediately for all sequence
 
 The pipeline execution ensures that the range of sequence values is known to be safe, meaning that there are no more transactions that might produce sequence values that are within the range. This is ensured by waiting for concurrent write transactions before proceeding with the command. The size of the range is effectively the number of inserts since the last time the pipeline was executed up to the moment that the new pipeline execution started. This technique was first introduced on the [Citus Data blog](https://www.citusdata.com/blog/2018/06/14/scalable-incremental-data-aggregation/) by the author of this extension.
 
+#### Limiting batch size
+
+By default, sequence pipelines process all available sequence values in a single execution. For scenarios where large batches of data are uploaded at once (e.g., daily bulk imports), you can use the `max_batch_size` parameter to limit how many sequence IDs are processed per execution:
+
+```sql
+-- Process at most 10,000 events per execution to avoid long-running transactions
+select incremental.create_sequence_pipeline(
+  'event-aggregation',
+  'events',
+  $$
+    insert into events_agg
+    select date_trunc('day', event_time), count(*)
+    from events
+    where event_id between $1 and $2
+    group by 1
+    on conflict (day) do update set event_count = events_agg.event_count + excluded.event_count;
+  $$,
+  schedule := '* * * * *',     -- Run every minute
+  max_batch_size := 10000      -- Process max 10k rows per run
+);
+```
+
+With `max_batch_size` set, if 100,000 new events arrive, the pipeline will process them in chunks of 10,000 over multiple executions rather than all at once. This helps to:
+- Avoid long-running transactions
+- Provide more predictable resource usage
+- Allow incremental progress on large data uploads
+
 The benefit of sequence pipelines is that they can process the data in small incremental steps and it is agnostic to where the timestamps used in aggregations came from (i.e. late data is fine). The downside is that you almost always have to merge aggregates using an ON CONFLICT clause, and there are situations where that is not possible (e.g. exact distinct counts).
 
 Arguments of the `incremental.create_sequence_pipeline` function:
@@ -116,6 +143,7 @@ Arguments of the `incremental.create_sequence_pipeline` function:
 | `sequence_name`       | regclass | Name of a sequence or table with a sequence        | Required                     |
 | `command`             | text     | Pipeline command with $1 and $2 parameters         | Required                     |
 | `schedule`            | text     | pg\_cron schedule for periodic execution (or NULL) | `* * * * *` (every minute)   |
+| `max_batch_size`      | bigint   | Maximum number of sequence IDs to process per run  | NULL (unlimited)             |
 | `execute_immediately` | bool     | Execute command immediately for existing data      | `true`                       |
 
 ### Creating a time interval pipeline
@@ -256,12 +284,12 @@ See the last processed sequence number in a sequence pipeline:
 
 ```sql
 select * from incremental.sequence_pipelines ;
-┌─────────────────────┬────────────────────────────┬────────────────────────────────┐
-│    pipeline_name    │       sequence_name        │ last_processed_sequence_number │
-├─────────────────────┼────────────────────────────┼────────────────────────────────┤
-│ view-count-pipeline │ public.events_event_id_seq │                        3000000 │
-│ event-aggregation   │ events_event_id_seq        │                        1000000 │
-└─────────────────────┴────────────────────────────┴────────────────────────────────┘
+┌─────────────────────┬────────────────────────────┬────────────────────────────────┬────────────────┐
+│    pipeline_name    │       sequence_name        │ last_processed_sequence_number │ max_batch_size │
+├─────────────────────┼────────────────────────────┼────────────────────────────────┼────────────────┤
+│ view-count-pipeline │ public.events_event_id_seq │                        3000000 │                │
+│ event-aggregation   │ events_event_id_seq        │                        1000000 │          10000 │
+└─────────────────────┴────────────────────────────┴────────────────────────────────┴────────────────┘
 ```
 
 See the last processed time interval in a time interval pipeline:

--- a/include/crunchy/incremental/sequence.h
+++ b/include/crunchy/incremental/sequence.h
@@ -1,6 +1,6 @@
 #pragma once
 
-void		InitializeSequencePipelineState(char *pipelineName, Oid sequenceId);
+void		InitializeSequencePipelineState(char *pipelineName, Oid sequenceId, int64 maxBatchSize);
 void		UpdateLastProcessedSequenceNumber(char *pipelineName, int64 lastSequenceNumber);
 void		ExecuteSequenceRangePipeline(char *pipelineName, char *command);
 Oid			FindSequenceForRelation(Oid relationId);

--- a/pg_incremental--1.3--1.4.sql
+++ b/pg_incremental--1.3--1.4.sql
@@ -1,0 +1,15 @@
+ALTER TABLE incremental.sequence_pipelines ADD COLUMN max_batch_size bigint;
+
+DROP FUNCTION incremental.create_sequence_pipeline(text,regclass,text,text,bool);
+CREATE FUNCTION incremental.create_sequence_pipeline(
+    pipeline_name text,
+    source_table_name regclass,
+    command text,
+    schedule text default '* * * * *',
+    max_batch_size bigint default NULL,
+    execute_immediately bool default true)
+ RETURNS void
+ LANGUAGE C
+AS 'MODULE_PATHNAME', $function$incremental_create_sequence_pipeline$function$;
+COMMENT ON FUNCTION incremental.create_sequence_pipeline(text,regclass,text,text,bigint,bool)
+ IS 'create a pipeline of new sequence ranges';

--- a/pg_incremental.control
+++ b/pg_incremental.control
@@ -1,5 +1,5 @@
 comment = 'Incremental Processing by Crunchy Data'
-default_version = '1.3'
+default_version = '1.4'
 module_pathname = '$libdir/pg_incremental'
 relocatable = false
 schema = pg_catalog

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -61,7 +61,8 @@ incremental_create_sequence_pipeline(PG_FUNCTION_ARGS)
 	Oid			sequenceId = PG_GETARG_OID(1);
 	char	   *command = text_to_cstring(PG_GETARG_TEXT_P(2));
 	char	   *schedule = PG_ARGISNULL(3) ? NULL : text_to_cstring(PG_GETARG_TEXT_P(3));
-	bool		executeImmediately = PG_ARGISNULL(4) ? false : PG_GETARG_BOOL(4);
+	int64		maxBatchSize = PG_ARGISNULL(4) ? 0 : PG_GETARG_INT64(4);
+	bool		executeImmediately = PG_ARGISNULL(5) ? false : PG_GETARG_BOOL(5);
 
 	char	   *searchPath = pstrdup(namespace_search_path);
 
@@ -110,7 +111,7 @@ incremental_create_sequence_pipeline(PG_FUNCTION_ARGS)
 	ParseQuery(command, paramTypes);
 
 	InsertPipeline(pipelineName, SEQUENCE_RANGE_PIPELINE, sourceRelationId, command, searchPath);
-	InitializeSequencePipelineState(pipelineName, sequenceId);
+	InitializeSequencePipelineState(pipelineName, sequenceId, maxBatchSize);
 
 	if (executeImmediately)
 		ExecutePipeline(pipelineName, SEQUENCE_RANGE_PIPELINE, command, searchPath);

--- a/src/sequence.c
+++ b/src/sequence.c
@@ -40,7 +40,7 @@ PG_FUNCTION_INFO_V1(incremental_sequence_range);
  * InitializeSequencePipelineStats adds the initial sequence pipeline state.
  */
 void
-InitializeSequencePipelineState(char *pipelineName, Oid sequenceId)
+InitializeSequencePipelineState(char *pipelineName, Oid sequenceId, int64 maxBatchSize)
 {
 	Oid			savedUserId = InvalidOid;
 	int			savedSecurityContext = 0;
@@ -54,18 +54,19 @@ InitializeSequencePipelineState(char *pipelineName, Oid sequenceId)
 
 	char	   *query =
 		"insert into incremental.sequence_pipelines "
-		"(pipeline_name, sequence_name) "
-		"values ($1, $2)";
+		"(pipeline_name, sequence_name, max_batch_size) "
+		"values ($1, $2, $3)";
 
 	bool		readOnly = false;
 	int			tupleCount = 0;
-	int			argCount = 2;
-	Oid			argTypes[] = {TEXTOID, OIDOID};
+	int			argCount = 3;
+	Oid			argTypes[] = {TEXTOID, OIDOID, INT8OID};
 	Datum		argValues[] = {
 		CStringGetTextDatum(pipelineName),
-		ObjectIdGetDatum(sequenceId)
+		ObjectIdGetDatum(sequenceId),
+		Int64GetDatum(maxBatchSize)
 	};
-	char	   *argNulls = "   ";
+	char	   *argNulls = maxBatchSize > 0 ? "   " : "  n";
 
 	SPI_connect();
 	SPI_execute_with_args(query,
@@ -194,7 +195,8 @@ GetSequenceNumberRange(char *pipelineName)
 	char	   *query =
 		"select"
 		" last_processed_sequence_number + 1,"
-		" pg_catalog.pg_sequence_last_value(sequence_name) seq "
+		" pg_catalog.pg_sequence_last_value(sequence_name) seq,"
+		" max_batch_size "
 		"from incremental.sequence_pipelines "
 		"where pipeline_name operator(pg_catalog.=) $1 "
 		"for update";
@@ -238,6 +240,26 @@ GetSequenceNumberRange(char *pipelineName)
 
 	if (!rangeEndIsNull)
 		range->rangeEnd = DatumGetInt64(rangeEndDatum);
+
+	/* read max_batch_size and apply limit if set */
+	bool		maxBatchSizeIsNull = false;
+	Datum		maxBatchSizeDatum = SPI_getbinval(row, rowDesc, 3, &maxBatchSizeIsNull);
+
+	if (!maxBatchSizeIsNull)
+	{
+		int64		maxBatchSize = DatumGetInt64(maxBatchSizeDatum);
+
+		if (maxBatchSize > 0 && range->rangeStart <= range->rangeEnd)
+		{
+			uint64		availableRange = range->rangeEnd - range->rangeStart + 1;
+
+			if (availableRange > maxBatchSize)
+			{
+				/* limit the range to max_batch_size */
+				range->rangeEnd = range->rangeStart + maxBatchSize - 1;
+			}
+		}
+	}
 
 	SPI_finish();
 


### PR DESCRIPTION
You can now define a sequence pipeline with a new max_batch_size argument like so
```
select incremental.create_sequence_pipeline('event-aggregation', 'events', $$
  insert into events_agg
  select date_trunc('day', event_time), count(*)
  from events
  where event_id between $1 and $2
  group by 1
  on conflict (day) do update set event_count = events_agg.event_count + excluded.event_count;
$$,
'* * * * *',
500,
true
);
```

This will limit the pipeline to only process n number of rows in one execution. This is useful if you have big daily uploads of data that dump millions of rows into a table that you then need to process. This allows you to process the new rows piecemeal instead of the pipeline choking on a million rows at a time.